### PR TITLE
Getting started 1.20.5, and below 1.17

### DIFF
--- a/getting-started/creating-project.md
+++ b/getting-started/creating-project.md
@@ -56,8 +56,10 @@ To create a project using the MCDev project wizard, press "New Project" on the "
 
 You'll want to select the "Minecraft" generator in the left sidebar.
 
-Make sure that you have selected "Mod" for the Platform Type toggle, "Fabric" for the loader toggle, and that a Java 17 JDK is selected at the bottom:
+Make sure that you have selected "Mod" for the Platform Type toggle, and "Fabric" for the loader toggle. If you are developing for 1.18-1.20.4 use Java 17:
 
 ![](./_assets/creating-a-project_0.png)
+
+If developing for 1.16.5 and below, use Java 8, and for 1.20.5 and up use Java 21.
 
 Click "Create" to start the project creation process - this may take a few minutes, don't close the IDE or cancel during this process or you will have to delete the folder your project was created in and restart!

--- a/getting-started/creating-project.md
+++ b/getting-started/creating-project.md
@@ -56,7 +56,7 @@ To create a project using the MCDev project wizard, press "New Project" on the "
 
 You'll want to select the "Minecraft" generator in the left sidebar.
 
-Make sure that you have selected "Mod" for the Platform Type toggle, and "Fabric" for the loader toggle. If you are developing for 1.18-1.20.4 use Java 17:
+Make sure that you have selected "Mod" for the Platform Type toggle, and "Fabric" for the loader toggle. If you are developing for 1.18-1.20.4 use Java 17 as the JDK:
 
 ![](./_assets/creating-a-project_0.png)
 


### PR DESCRIPTION
The getting started page talked about JVM's and how you should be using Java 17 for your JDK, but as of 1.20.5 the required JDK for Minecraft has changed to Java 21. I added a sentence on how for 1.20.5 and up you should use Java 21, while for 1.16.5 and below you should be using Java 8.